### PR TITLE
Class PTEC (bleu) 1291

### DIFF
--- a/core/class/teleinfo.class.php
+++ b/core/class/teleinfo.class.php
@@ -1287,6 +1287,20 @@ class teleinfo extends eqLogic {
 			$cmd->setEventOnly(1);
 			$cmd->setIsVisible(1);
 			$cmd->save();
+			$cmd = null;
+                        $cmd = new teleinfoCmd();
+                        $cmd->setName('Plage Horaires');
+                        $cmd->setEqLogic_id($this->id);
+                        $cmd->setLogicalId('PTEC');
+                        $cmd->setType('info');
+                        $cmd->setConfiguration('info_conso', 'PTEC');
+                        $cmd->setDisplay('generic_type','DONT');
+                        $cmd->setSubType('string');
+                        //$cmd->setUnite('');
+                        $cmd->setIsHistorized(0);
+                        $cmd->setEventOnly(1);
+                        $cmd->setIsVisible(1);
+                        $cmd->save();
 		}
 		
 	


### PR DESCRIPTION
Les info du PTEC ne sont pas remonté car la classe ptec n'existait pas pour la config "bleu". J'ai donc ajouté le necessaire afin que les info soit dispo dans jeedom